### PR TITLE
Removed reference to non-existing JS file in Gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -59,7 +59,6 @@ gulp.task('uglify', ['uglify-angular'], function() {
     'bower_components/viewport-units-buggyfill/viewport-units-buggyfill.js',
     'bower_components/notify.js/notify.js',
     'bower_components/tether/tether.js',
-    'bower_components/foundation-apps/js/foundation/**/*.js',
     'client/assets/js/app.js'
   ];
 


### PR DESCRIPTION
`bower_components/foundation-apps/js/foundation/**/*.js` references nothing because the `foundation-apps/js/foundation` does not exists. So I guess this can be removed.
