### PR TITLE
Repair copy-partials gulp task 

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,7 +34,7 @@ gulp.task('clean-partials', function(cb) {
 });
 
 gulp.task('copy-partials', ['clean-partials'], function() {
-  return gulp.src(['js/angular/partials/**.*'])
+  return gulp.src(['bower_components/foundation-apps/js/angular/partials/**.*'])
     .pipe(gulp.dest('./build/partials/'));
 });
 


### PR DESCRIPTION
The current copy-partials gulp task is attempting to copy partials from the wrong path. `foundation-apps new MyApp` uses bower to include foundation-apps, so the angular partials are in `bower_components/foundation-apps/js/angular/partials`.
