### PR TITLE
Gulpfile refactor

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Foundation Angular</title>
     <link href="/assets/css/app.css" rel="stylesheet" type="text/css">
-    <script src="/assets/js/dependencies.js"></script>
+    <script src="/assets/js/foundation.js"></script>
     <script src="/assets/js/routes.js"></script>
     <script src="/assets/js/app.js"></script>
   </head>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,11 @@
+// FOUNDATION FOR APPS TEMPLATE GULPFILE
+// -------------------------------------
+// This file processes all of the assets in the "client" folder, combines them with the Foundation
+// for Apps assets, and outputs the finished files in the "build" folder as a finished app.
+
+// 1. LIBRARIES
+// - - - - - - - - - - - - - - -
+
 var gulp           = require('gulp'),
     rimraf         = require('rimraf'),
     runSequence    = require('run-sequence'),
@@ -11,12 +19,39 @@ var gulp           = require('gulp'),
     modRewrite     = require('connect-modrewrite'),
     dynamicRouting = require('./bower_components/foundation-apps/bin/gulp-dynamic-routing');
 
-// Clean build directory
+// 2. SETTINGS VARIABLES
+// - - - - - - - - - - - - - - -
+
+// Sass will check these folders for files when you use @import.
+var sassPaths = [
+  'bower_components/foundation-apps/scss',
+  'client/assets/scss'
+];
+// These files include Foundation for Apps and its dependencies
+var foundationJS = [
+  'bower_components/fastclick/lib/fastclick.js',
+  'bower_components/viewport-units-buggyfill/viewport-units-buggyfill.js',
+  'bower_components/tether/tether.js',
+  'bower_components/angular/angular.js',
+  'bower_components/angular-animate/angular-animate.js',
+  'bower_components/ui-router/release/angular-ui-router.js',
+  'bower_components/foundation-apps/js/vendor/**/*.js',
+  'bower_components/foundation-apps/js/angular/**/*.js'
+];
+// These files are for your app's JavaScript
+var appJS = [
+  'client/assets/js/app.js'
+];
+
+// 3. TASKS
+// - - - - - - - - - - - - - - -
+
+// Cleans the build directory
 gulp.task('clean', function(cb) {
   rimraf('./build', cb);
 });
 
-// Copy static files (but not the Angular templates, Sass, or JS)
+// Copies user-created files and Foundation assets
 gulp.task('copy', function() {
   var dirs = [
     './client/**/*.*',
@@ -24,28 +59,26 @@ gulp.task('copy', function() {
     '!./client/assets/{scss,js}/**/*.*'
   ];
 
+  // Everything in the client folder except templates, Sass, and JS
   gulp.src(dirs, {
     base: './client/'
   })
-    .pipe(gulp.dest('build'));
+    .pipe(gulp.dest('./build'));
 
-  return gulp.src('bower_components/foundation-apps/iconic/**/*')
-    .pipe(gulp.dest('build/assets/img/iconic/'));
-});
+  // Iconic SVG icons
+  gulp.src('./bower_components/foundation-apps/iconic/**/*')
+    .pipe(gulp.dest('./build/assets/img/iconic/'));
 
-gulp.task('clean-partials', function(cb) {
-  rimraf('./build/partials', cb);
-});
-
-gulp.task('copy-partials', ['clean-partials'], function() {
-  return gulp.src(['bower_components/foundation-apps/js/angular/partials/**.*'])
+  // Foundation's Angular partials
+  return gulp.src(['./bower_components/foundation-apps/js/angular/partials/**.*'])
     .pipe(gulp.dest('./build/partials/'));
 });
 
+// Compiles Sass
 gulp.task('sass', function() {
   return gulp.src('client/assets/scss/app.scss')
     .pipe(sass({
-      loadPath: ['bower_components/foundation-apps/scss', 'client/assets/scss'],
+      loadPath: sassPaths,
       style: 'nested',
       bundleExec: true
     }))
@@ -58,62 +91,45 @@ gulp.task('sass', function() {
     .pipe(gulp.dest('./build/assets/css/'));
 });
 
-// Process Foundation JS
-gulp.task('uglify', ['uglify-angular'], function() {
-  var libs = [
-    'bower_components/jquery/dist/jquery.js',
-    'bower_components/fastclick/lib/fastclick.js',
-    'bower_components/viewport-units-buggyfill/viewport-units-buggyfill.js',
-    'bower_components/notify.js/notify.js',
-    'bower_components/tether/tether.js'
-  ];
-
-  return gulp.src(libs)
+// Compiles and copies the Foundation for Apps JavaScript, as well as your app's custom JS
+gulp.task('uglify', function() {
+  // Foundation JavaScript
+  gulp.src(foundationJS)
     .pipe(uglify({
       beautify: true,
       mangle: false
     }).on('error', function(e) {
       console.log(e);
     }))
-    .pipe(concat('dependencies.js'))
+    .pipe(concat('foundation.js'))
     .pipe(gulp.dest('./build/assets/js/'))
   ;
-});
 
-// Process Angular JS
-gulp.task('uglify-angular', function() {
-  var libs = [
-    'bower_components/angular/angular.js',
-    'bower_components/angular-animate/angular-animate.js',
-    'bower_components/ui-router/release/angular-ui-router.js',
-    'bower_components/foundation-apps/js/vendor/**/*.js',
-    'bower_components/foundation-apps/js/angular/**/*.js',
-    'client/assets/js/app.js'
-  ];
-
-  return gulp.src(libs)
+  // App JavaScript
+  return gulp.src(appJS)
     .pipe(uglify({
       beautify: true,
       mangle: false
+    }).on('error', function(e) {
+      console.log(e);
     }))
     .pipe(concat('app.js'))
     .pipe(gulp.dest('./build/assets/js/'))
   ;
-
 });
 
-gulp.task('copy-templates', ['copy'], function() {
-  var config = [];
-
+// Copies your app's page templates and generates URLs for them
+gulp.task('copy-pages', ['copy'], function() {
   return gulp.src('./client/templates/**/*.html')
     .pipe(dynamicRouting({
       path: 'build/assets/js/routes.js',
       root: 'client'
     }))
-    .pipe(gulp.dest('build/templates'))
+    .pipe(gulp.dest('./build/templates'))
   ;
 });
 
+// Starts a test server, which you can view at http://localhost:8080
 gulp.task('server:start', function() {
   connect.server({
     root: './build',
@@ -125,15 +141,15 @@ gulp.task('server:start', function() {
   });
 });
 
+// Builds your entire app once, without starting a server
 gulp.task('build', function() {
-  runSequence('clean', ['copy', 'copy-partials', 'sass', 'uglify'], 'copy-templates', function() {
+  runSequence('clean', ['copy', 'sass', 'uglify'], 'copy-pages', function() {
     console.log("Successfully built.");
   })
 });
 
+// Default task: builds your app, starts a server, and recompiles assets when they change
 gulp.task('default', ['build', 'server:start'], function() {
-  // gulp.watch(['./client/**/*.*', './js/**/*.*'], ['build', 'css', server.restart]);
-
   // Watch Sass
   gulp.watch(['./client/assets/scss/**/*', './scss/**/*'], ['sass']);
 
@@ -143,9 +159,6 @@ gulp.task('default', ['build', 'server:start'], function() {
   // Watch static files
   gulp.watch(['./client/**/*.*', '!./client/templates/**/*.*', '!./client/assets/{scss,js}/**/*.*'], ['copy']);
 
-  // Watch Angular partials
-  gulp.watch(['js/angular/partials/**.*'], ['copy-partials']);
-
-  // Watch Angular templates
+  // Watch app templates
   gulp.watch(['./client/templates/**/*.html'], ['copy-templates']);
 });


### PR DESCRIPTION
This reworking of the template's `gulpfile.js` tries to streamline things, and also switch around how files are imported based on some internal discussions.

Here are the changes:
- The `copy-partials` task was merged into the regular `copy` task, and removed the corresponding watcher. A separate task isn't needed for the template repo, because those files will never change.
  - This also makes the `clean-partials` task unnecessary, so it was removed as well.
- The two tasks for processing JavaScript were combined into one task.
  - All framework code and dependencies are now compiled into one `foundation.js` file. The user's project-specific code is compiled to `app.js`. This mimics the model we use in Foundation 5. Also, if we eventually transfer this method of compiling back to the main repo, it sets us up to eventually host the Apps JS on a CDN, in which case we'd want everything you need in one file.
  - I also temporarily removed two libraries I don't think we're using: jQuery and notify.js. At least, I don't _think_ we're using jQuery, or I assumed we weren't, and it was still being compiled in by accident.
- Moved the big arrays of directories—for compiling Sass and JavaScript—to the top of the file so they're easer to find and change.
- Added a bunch of comments better explaining what each task does.

This pares down the build process to four essential tasks: copying files, compiling Sass, compiling JS, and copying pages/processing routes. Hopefully this will make the file easier to understand.

**_Unfortunately**_, I must not have the import order for the JavaScript right, because I get this error on startup:

```
Uncaught Error: [$injector:unpr] Unknown provider: $$jqLiteProvider <- $$jqLite <- $animate <- $compile
```

I tried imitating the order the files are processed in the current Gulpfile, but it still doesn't seem to work. @AntJanus, I'll need your help making it go :)
