### PR TITLE
Packing partials along with javascript using gulp-angular-templatecache

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "through2": "^0.6.2",
     "connect-modrewrite": "^0.7.9",
     "rimraf": "^2.2.8",
-    "run-sequence": "^1.0.1"
+    "run-sequence": "^1.0.1",
+    "event-stream": "^3.1.7",
+    "gulp-order": "^1.1.1",
+    "gulp-angular-templatecache": "^1.4.2"
   },
   "private": true
 }


### PR DESCRIPTION
Packing partials along with javascript will improve performance and cleans up build process