### PR TITLE
Globstar / glob pattern to match components subdirectories path, in gulp copy task.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -71,7 +71,7 @@ gulp.task('copy', function() {
     .pipe(gulp.dest('./build/assets/img/iconic/'));
 
   // Foundation's Angular partials
-  return gulp.src(['./bower_components/foundation-apps/js/angular/components/**.*'])
+  return gulp.src(['./bower_components/foundation-apps/js/angular/components/**/**.*'])
     .pipe(gulp.dest('./build/components/'));
 });
 


### PR DESCRIPTION
The current path / glob pattern was not work for the copy task, so its failed to copy components subdirectories when gulp run.

    ./bower_components/foundation-apps/js/angular/components/**.*

Glob pattern expecting {something/dir}.{0 or more characters in a single path portion/extension}, there's no file except >= 1 subdirectories in it. Change to:

    ./bower_components/foundation-apps/js/angular/components/**/**.*

then it matches zero or more directories / subdirectories.