### PR TITLE
Fix copying of angular partials

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -71,7 +71,7 @@ gulp.task('copy', function() {
     .pipe(gulp.dest('./build/assets/img/iconic/'));
 
   // Foundation's Angular partials
-  return gulp.src(['./bower_components/foundation-apps/js/angular/components/**.*'])
+  return gulp.src(['./bower_components/foundation-apps/js/angular/components/**/*.html'])
     .pipe(gulp.dest('./build/components/'));
 });
 


### PR DESCRIPTION
Fixes - Foundation components aren't copied to the build directory.

https://github.com/zurb/foundation-apps-template/issues/16