### PR TITLE
Version 1.1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "foundation-apps-template",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "authors": [
     "ZURB"
   ],

--- a/client/index.html
+++ b/client/index.html
@@ -14,16 +14,9 @@
       <div class="grid-content shrink" style="padding: 0;">
         <ul class="primary condense menu-bar">
           <li><a><strong>Foundation for Apps</strong></a></li>
-          <li><a ui-sref="home">Home</a></li>
-          <li><a ui-sref="home">About</a></li>
-          <li><a ui-sref="home">News</a></li>
-          <li><a ui-sref="home">Contact</a></li>
         </ul>
       </div>
-      <div class="grid-content">
-        <div class="grid-container">
-          <div ng-class="['ui-animation']" ui-view></div>
-        </div>
+      <div ui-view class="grid-content">
       </div>
     </div>
   </body>

--- a/client/index.html
+++ b/client/index.html
@@ -6,6 +6,7 @@
     <title>Foundation for Apps</title>
     <link href="/assets/css/app.css" rel="stylesheet" type="text/css">
     <script src="/assets/js/foundation.js"></script>
+    <script src="/assets/js/templates.js"></script>
     <script src="/assets/js/routes.js"></script>
     <script src="/assets/js/app.js"></script>
   </head>

--- a/client/templates/home.html
+++ b/client/templates/home.html
@@ -3,5 +3,7 @@ name: home
 url: /
 ---
 
-<h1>Welcome to Foundation for Apps!</h1>
-<p class="lead">This is version <strong>1.0.3 Matterhorn</strong>.</p>
+<div class="grid-container">
+  <h1>Welcome to Foundation for Apps!</h1>
+  <p class="lead">This is version <strong>1.1 Weisshorn</strong>.</p>
+</div>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -159,5 +159,5 @@ gulp.task('default', function () {
   gulp.watch(['./client/**/*.*', '!./client/templates/**/*.*', '!./client/assets/{scss,js}/**/*.*'], ['copy']);
 
   // Watch app templates
-  gulp.watch(['./client/templates/**/*.html'], ['copy-templates']);
+  gulp.watch(['./client/templates/**/*.html'], ['copy:templates']);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foundation-apps-template",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "scripts": {
     "start": "gulp"
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "gulp-concat": "^2.4.2",
     "gulp-load-plugins": "^0.8.0",
     "gulp-ruby-sass": "^0.7.1",
+    "gulp-sass": "^1.3.3",
     "gulp-uglify": "^1.0.2",
     "gulp-util": "^3.0.1",
     "gulp-webserver": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "gulp-autoprefixer": "^1.0.1",
     "gulp-concat": "^2.4.2",
     "gulp-load-plugins": "^0.8.0",
+    "gulp-ng-html2js": "^0.2.0",
     "gulp-ruby-sass": "^0.7.1",
     "gulp-sass": "^1.3.3",
     "gulp-uglify": "^1.0.2",

--- a/readme.md
+++ b/readme.md
@@ -1,17 +1,18 @@
 # Foundation for Apps Template
 
-This is the default template project for Foundation for Apps. It's powered by Node, Gulp, Angular, and libsass. It provides you with a basic template to get started with Angular and Foundation for Apps. If you're already an Angular developer, you may instead want to install the components into your own stack using Bower: `bower install foundation-apps`
+This is the default template project for Foundation for Apps, powered by Gulp, Angular, and libsass. It provides you with a basic template to get started with Foundation for Apps and Angular.
+
+If you're already an Angular developer, you may instead want to install the components into your own stack using Bower: `bower install foundation-apps`
 
 ## Requirements
 
 You'll need the following software installed to get started.
 
-  * [Node.js](http://nodejs.org): Use the installer provided on the NodeJS website.
-  * [Git](http://git-scm.com/downloads): Use the installer for your OS.
-    * Windows users can also try [Git for Windows](http://git-for-windows.github.io/).
-  * [Ruby](https://www.ruby-lang.org/en/): Use the installer for your OS. For Windows users, [JRuby](http://jruby.org/) is a popular alternative.
-    * With Ruby installed, run `gem install bundler sass`.
-  * [Gulp](http://gulpjs.com/) and [Bower](http://bower.io): Run `[sudo] npm install -g gulp bower`
+  - [Node.js](http://nodejs.org): Use the installer for your OS.
+  - [Git](http://git-scm.com/downloads): Use the installer for your OS.
+    - Windows users can also try [Git for Windows](http://git-for-windows.github.io/).
+  - [Gulp](http://gulpjs.com/) and [Bower](http://bower.io): Run `npm install -g gulp bower`
+    - Depending on how Node is configured on your machine, you may need to run `sudo npm install -g gulp bower` instead, if you get an error with the first command.
 
 ## Get Started
 
@@ -27,12 +28,11 @@ Change into the directory.
 cd app
 ```
 
-Install the dependencies. Running `npm install` will also automatically run `bower install` after. If you're running Mac OS or Linux, you may need to run `sudo npm install` instead, depending on how your machine is configured. Running `bundle` will install the correct version of Sass for the template.
+Install the dependencies.If you're running Mac OS or Linux, you may need to run `sudo npm install` instead, depending on how your machine is configured.
 
 ```bash
 npm install
 bower install
-bundle
 ```
 
 While you're working on your project, run:
@@ -41,9 +41,9 @@ While you're working on your project, run:
 npm start
 ```
 
-This will compile the Sass and assemble your Angular app. **Now go to `localhost:8080` in your browser to see it in action.**
+This will compile the Sass and assemble your Angular app. **Now go to `localhost:8080` in your browser to see it in action.** When you change any file in the `client` folder, the appropriate Gulp task will run to build new files.
 
-To run the compiling process once, without watching any files:
+To run the compiling process once, without watching any files, use the `build` command.
 
 ```bash
 npm start build

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ Change into the directory.
 cd app
 ```
 
-Install the dependencies.If you're running Mac OS or Linux, you may need to run `sudo npm install` instead, depending on how your machine is configured.
+Install the dependencies. If you're running Mac OS or Linux, you may need to run `sudo npm install` instead, depending on how your machine is configured.
 
 ```bash
 npm install


### PR DESCRIPTION
This updates the template to use version 1.1 of Foundation for Apps, uses Node instead of Ruby to compile Sass, and simplifies the starter page.

- [x] Use version 1.1 of Foundation for Apps
- [x] Compile Sass with Node instead of Ruby
- [x] Simplify starter page
- [x] Add LiveReload
- [x] Add ng-html2js
- [x] Add editorconfig
- [x] Refactor tasks to be a little more efficient