### PR TITLE
Emit 'end' event for the sass task errors to allow gulp to continue to run. Fix #27.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -104,6 +104,10 @@ gulp.task('sass', function () {
       includePaths: paths.sass,
       outputStyle: (isProduction ? 'compressed' : 'nested'),
       errLogToConsole: true
+    })
+    .on('error', function (e) {
+      console.log(e);
+      this.emit('end');
     }))
     .pipe($.autoprefixer({
       browsers: ['last 2 versions', 'ie 10']


### PR DESCRIPTION
This pull request addresses #27. Thank you for considering it!
